### PR TITLE
Update dashboard parameters for ICP archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ This repository contains the Puppet modules for WSO2 Micro Integrator.
 * Change Java distribution in site.pp file according to your requirement. [Refer](https://forge.puppet.com/modules/puppetlabs/java/readme)
 * Add any configuration changes required to `/modules/micro_integrator/templates/conf/deployment.toml.erb` file and use puppet config management to manage them. ( Facter, Hiera, etc. )
 * You can add any custom code to `/modules/micro_integrator/custom.pp`.
+
+## Configuration
+
+The `mi_dashboard` module exposes a few parameters that can be tuned via Hiera
+or directly in your manifests.
+
+- `archive_name_base`  - Name of the ICP archive without the version
+  (default: `integration-control-plane`).
+- `install_dir_name`   - Directory name that the archive extracts to. By
+  default this is constructed as `<archive_name_base>-<product_version>`.
+
+To override the archive name in Hiera:
+
+```yaml
+mi_dashboard::archive_name_base: 'custom-icp'
+```

--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ This repository contains the Puppet modules for WSO2 Micro Integrator.
 The `mi_dashboard` module exposes a few parameters that can be tuned via Hiera
 or directly in your manifests.
 
-- `archive_name_base`  - Name of the ICP archive without the version
-  (default: `integration-control-plane`).
-- `install_dir_name`   - Directory name that the archive extracts to. By
-  default this is constructed as `<archive_name_base>-<product_version>`.
+- `archive_name`      - The ICP dashboard zip file to install. Defaults to
+  `integration-control-plane-<product_version>.zip`.
+- `archive_name_base` - The archive name without the `.zip` extension. This is
+  derived from `archive_name` and normally doesn't need manual changes.
+- `install_dir_name`  - Directory created by extracting the archive. Defaults
+  to the value of `archive_name_base`.
 
 To override the archive name in Hiera:
 
 ```yaml
-mi_dashboard::archive_name_base: 'custom-icp'
+mi_dashboard::archive_name: 'custom-icp-1.0.zip'
 ```

--- a/modules/mi_dashboard/manifests/init.pp
+++ b/modules/mi_dashboard/manifests/init.pp
@@ -134,15 +134,12 @@ class mi_dashboard inherits mi_dashboard::params {
 
   # Copy the unit file required to deploy the server as a service
   file { '/etc/systemd/system/wso2mi-dashboard.service':
-    ensure  => present,
+    ensure  => file,
     owner   => root,
     group   => root,
     mode    => '0754',
     content => template('mi_dashboard/wso2mi-dashboard.service.erb'),
-    vars    => {
-      product_version  => $product_version,
-      install_dir_name => $install_dir_name,
-    },
+    notify  => Service[$service_name],
   }
 
   # Add agent specific file configurations

--- a/modules/mi_dashboard/manifests/init.pp
+++ b/modules/mi_dashboard/manifests/init.pp
@@ -133,12 +133,16 @@ class mi_dashboard inherits mi_dashboard::params {
   }
 
   # Copy the unit file required to deploy the server as a service
-  file { "/etc/systemd/system/${service_name}.service":
+  file { '/etc/systemd/system/wso2mi-dashboard.service':
     ensure  => present,
     owner   => root,
     group   => root,
     mode    => '0754',
-    content => template("${module_name}/${service_name}.service.erb"),
+    content => template('mi_dashboard/wso2mi-dashboard.service.erb'),
+    vars    => {
+      product_version  => $product_version,
+      install_dir_name => $install_dir_name,
+    },
   }
 
   # Add agent specific file configurations

--- a/modules/mi_dashboard/manifests/params.pp
+++ b/modules/mi_dashboard/manifests/params.pp
@@ -27,6 +27,11 @@ class mi_dashboard::params {
 
   $product = 'wso2mi-dashboard'
   $product_version = '4.3.0'
+
+  # Default ICP ZIP name
+  $archive_name_base = 'integration-control-plane'
+  # Directory name to install into
+  $install_dir_name  = "${archive_name_base}-${product_version}"
   $service_name = "${product}"
 
   # Define the template
@@ -38,9 +43,10 @@ class mi_dashboard::params {
   $java_home = "/usr"
 
   # Product and installation information
-  $product_binary = "${product}-${product_version}.zip"
+  $archive_name = "${archive_name_base}-${product_version}.zip"
+  $product_binary = $archive_name
   $distribution_path = "${products_dir}/${product}/${product_version}"
-  $install_path = "${distribution_path}/${product}-${product_version}"
+  $install_path = "${distribution_path}/${install_dir_name}"
 
   # ---- Configuration parameters for deployment.toml ---- #
   $server_config_port = 9743

--- a/modules/mi_dashboard/manifests/params.pp
+++ b/modules/mi_dashboard/manifests/params.pp
@@ -28,10 +28,12 @@ class mi_dashboard::params {
   $product = 'wso2mi-dashboard'
   $product_version = '4.3.0'
 
-  # Default ICP ZIP name
-  $archive_name_base = 'integration-control-plane'
+  # Name of the ICP dashboard archive
+  $archive_name = "integration-control-plane-${product_version}.zip"
+  # Derive base directory name from the archive
+  $archive_name_base = regsubst($archive_name, '\.zip$', '', 'G')
   # Directory name to install into
-  $install_dir_name  = "${archive_name_base}-${product_version}"
+  $install_dir_name  = $archive_name_base
   $service_name = "${product}"
 
   # Define the template
@@ -43,7 +45,6 @@ class mi_dashboard::params {
   $java_home = "/usr"
 
   # Product and installation information
-  $archive_name = "${archive_name_base}-${product_version}.zip"
   $product_binary = $archive_name
   $distribution_path = "${products_dir}/${product}/${product_version}"
   $install_path = "${distribution_path}/${install_dir_name}"

--- a/modules/mi_dashboard/templates/wso2mi-dashboard.service.erb
+++ b/modules/mi_dashboard/templates/wso2mi-dashboard.service.erb
@@ -3,10 +3,10 @@ Description=WSO2 Micro Integrator Dashboard
 After=network.target
 
 [Service]
-ExecStart=/bin/sh <%=@install_path%>/bin/dashboard.sh start
-ExecStop=/bin/sh <%=@install_path%>/bin/dashboard.sh stop
-ExecReload=/bin/sh <%=@install_path%>/bin/dashboard.sh restart
-PIDFile=<%=@install_path%>/runtime.pid
+ExecStart=/bin/sh /usr/local/wso2/wso2mi-dashboard/<%= @product_version %>/<%= @install_dir_name %>/bin/dashboard.sh start
+ExecStop=/bin/sh /usr/local/wso2/wso2mi-dashboard/<%= @product_version %>/<%= @install_dir_name %>/bin/dashboard.sh stop
+ExecReload=/bin/sh /usr/local/wso2/wso2mi-dashboard/<%= @product_version %>/<%= @install_dir_name %>/bin/dashboard.sh restart
+PIDFile=/usr/local/wso2/wso2mi-dashboard/<%= @product_version %>/<%= @install_dir_name %>/runtime.pid
 User=<%=@user%>
 Group=<%=@user_group%>
 Type=forking


### PR DESCRIPTION
## Summary
- support ICP package naming via `archive_name_base` and `install_dir_name`
- update service template and template resource
- document new parameters

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686248af2c208331b9ee2e571bc5848f